### PR TITLE
Make the e-steps calculation work for lengths other 100

### DIFF
--- a/octoprint_CalibrationTools/static/js/EStepsViewModel.js
+++ b/octoprint_CalibrationTools/static/js/EStepsViewModel.js
@@ -33,7 +33,7 @@ $(function () {
             return self.generalVM.round(self.testParam.markLength() - self.results.remainedLength());
         });
         self.results["newSteps"] = ko.computed(function () {
-            return self.generalVM.round(self.steps.E() / self.results.actualExtrusion() * 100);
+            return self.generalVM.round((self.steps.E() * self.testParam.extrudeLength()) / self.results.actualExtrusion());
         });
         // self.results["newStepsDisplay"] = ko.computed(function () {
         //     return "M92 E" + self.results.newSteps();


### PR DESCRIPTION
Currently the formula works only for lengths of 100. If you do anything other than 100 the formula breaks and you will get a bad esteps calculation. the formula is this:

(steps taken) / (actual length extruded) = (new steps/mm value)

where:
(steps/mm value) x (length of filament extruded) = (steps taken)

(length from extruder to mark pre extrusion) – (length from extruder to mark after extrusion) = (actual length extruded)

Currently the length of filament extruded is hard coded to 100 in your formula. I found this because my printer is under extruding due to this formula