### PR TITLE
Support for Prusa MK3S M503 command (Marlin > 2.0.9.3)

### DIFF
--- a/octoprint_CalibrationTools/EStepsApi.py
+++ b/octoprint_CalibrationTools/EStepsApi.py
@@ -34,6 +34,12 @@ class API(octoprint.plugin.SimpleApiPlugin):
 
             # Issue M92 command
             self._printer.commands("M92")
+            # Issue M503 command to read values from EEPROM on Prusa MK3S (Marlin > Marlin 2.0.9.3)
+            # I hope I understand the Response handler correctly - that it parses the response and looks for presence of a line
+            # in the following format:
+            # M92 Xn Yn Zn En
+            self._printer.commands("M503")
+            
 
             m92Event.wait(5)
 


### PR DESCRIPTION
The plugin deesn't load values from EEPROM on Prusa MK3S, because the`M92` command is used for setting the steps only, not for reading](https://help.prusa3d.com/article/prusa-firmware-specific-g-code-commands_112173#:~:text=M92%20Set%20Axis,M500%20in%20Marlin)). That's done with the `M503` command, that dumps the settings  from EEPROM. 

I issue both commands and hope for the response parser to cope with that.

Hotfixes #27